### PR TITLE
fix: avoid invisible title to mislead `pagebreak`

### DIFF
--- a/src/api.typ
+++ b/src/api.typ
@@ -33,7 +33,7 @@
   // 加载 bib 数据
   let bib-data = load-bibliography(bib-content)
   // 创建隐藏的 bibliography（让 @key 语法工作）
-  hide(bibliography(bytes(bib-content)))
+  hide(bibliography(bytes(bib-content), title: none))
 
   // 设置状态
   _bib-data.update(bib-data)


### PR DESCRIPTION
Current implementation inserts a weird empty page before content if there is `pagebreak(weak: true)`. See https://typst.app/project/rAk5iaFkDJPvEkta6FEQh1

I tested locally that my patch fixes the bug, so now I am sending it to you :)
