### PR TITLE
fix(api): disable year suffix in numeric style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name suffix formatting: removed comma before suffix (per GB/T 7714-2025 examples)
   - Before: `King M L, Jr.`
   - After: `King M L Jr.`
-- Year suffix disambiguation now uses citation order instead of title alphabetical order (per GB/T 7714-2025 9.3.1.3)
+- Year suffix disambiguation now uses citation order instead of title alphabetical order (per GB/T 7714-2025 9.3.1.3)（[#6](https://github.com/pku-typst/gb7714-bilingual/pull/6)）
   - Before: suffixes assigned by title sort (could produce a, c, b)
   - After: suffixes assigned by citation order (always a, b, c in order of appearance)
 - Invisible hidden bibliography title no longer triggers unexpected page break with `pagebreak(weak: true)` ([#4](https://github.com/pku-typst/gb7714-bilingual/pull/4) by [@Coekjan](https://github.com/Coekjan))
+- Numeric style no longer incorrectly displays year suffixes (a, b, c) in bibliography （[#7](https://github.com/pku-typst/gb7714-bilingual/pull/7)）
 
 ## [0.2.0] - 2026-01-21
 

--- a/src/api.typ
+++ b/src/api.typ
@@ -209,7 +209,12 @@
       if entry == none { return none }
 
       let lang = detect-language(entry)
-      let year-suffix = suffixes.at(key, default: "")
+      // 顺序编码制不需要年份后缀消歧（用编号区分）
+      let year-suffix = if current-style == "numeric" {
+        ""
+      } else {
+        suffixes.at(key, default: "")
+      }
       let rendered = render-entry(
         entry,
         lang,


### PR DESCRIPTION
Numeric style uses citation numbers [1], [2] to distinguish references, so year suffixes (a, b, c) should not be displayed in bibliography.